### PR TITLE
Fix translation for "section"

### DIFF
--- a/book/install.md
+++ b/book/install.md
@@ -2,7 +2,7 @@
 > **Note:** If you do not want to install yet, you can follow along anyway. Most sections can be done in an online editor!
 -->
 
-> **お知らせ:** まだElmをインストールしたくない場合は、インストールをしないままでも構いません。ほとんどの章ではオンラインエディタで完結できます。
+> **お知らせ:** まだElmをインストールしたくない場合は、インストールをしないままでも構いません。ほとんどの節ではオンラインエディタで完結できます。
 
 
 <!--
@@ -131,7 +131,7 @@ Read <https://elm-lang.org/0.19.0/repl> to learn more: exit, help, imports, etc.
 $
 ```
 
-`elm repl`は&ldquo;Core Language&rdquo;の章で使います。詳しい使い方は[こちら](https://elm-lang.org/0.19.0/repl)をご覧ください。
+`elm repl`は&ldquo;Core Language&rdquo;の節で使います。詳しい使い方は[こちら](https://elm-lang.org/0.19.0/repl)をご覧ください。
 
 
 <!--

--- a/book/types/reading_types.md
+++ b/book/types/reading_types.md
@@ -6,7 +6,7 @@
 <!--
 In the [Core Language](../core_language.md) section of this book, we ran a bunch of code in the REPL. Well, we are going to do it again, but now with an emphasis on the types that are getting spit out. So type `elm repl` in your terminal again. You should see this:
 -->
-この本の[言語の基礎](../core_language.md)セクションでは、REPL で一連のコードを実行しました。 さて、私たちはもう一度やってみるつもりですが、今度は表示される型に注目していきましょう。 ターミナルに`elm repl`と入力してください。 このように表示されます:
+この本の[言語の基礎](../core_language.md)の節では、REPL で一連のコードを実行しました。 さて、私たちはもう一度やってみるつもりですが、今度は表示される型に注目していきましょう。 ターミナルに`elm repl`と入力してください。 このように表示されます:
 
 ```elm
 ---- Elm 0.19.0 ----------------------------------------------------------------


### PR DESCRIPTION
"section" の訳を 「節」で統一
"chapter" はすでに「章」になっていたのでそのままにしてあります。
This PR closes https://github.com/elm-jp/guide/issues/90