### PR TITLE
対訳表の一部の訳をコメントアウトする

### DIFF
--- a/book/about_translation.md
+++ b/book/about_translation.md
@@ -12,22 +12,37 @@
 この翻訳プロジェクトで使う訳語と元の英単語の対応を表に表しました。
 学習にお役立てください。
 
+<!--
+対訳表のうち、コメントアウトした行はウェブ上には表示されません `pretranslate` コマンドには読み込まれます。
+翻訳者の間で共有したほうが良いが、あえて読者に見せる必要はないような対訳を記載しておくと便利です。
+
+また、名詞はできるだけ単数形で記載してください。
+複数形が "s" や "es" をつけるだけの名詞の場合は単数形でそのまま単純に原文を検索すれば複数形もマッチするため、
+`pretranslate` コマンドがうまく原文から単語を見つけることができます。
+
+"industry" <-> "industries"
+"leaf" <-> "leaves"
+"kitchen knife" <-> "kitchen knives"
+のように特殊な活用をする単語の場合はコメントとして付記するといいでしょう。
+-->
+
 | 訳語              | 原文            |
 |:-----------------:|:---------------:|
 | 型の別名          | type alias      |
-| カスタム型        | custom types    |
 | オブジェクト指向  | object oriented |
 | テキスト入力      | text field      |
 | カスタム型        | custom type     |
 | パターンマッチ    | pattern match   |
 | 相互運用          | interop         |
-| カスタムエレメンツ| custom elements |
+| カスタムエレメンツ| custom element  |
 | パース            | parsing         |
 | パースする        | parse           |
-| ソースコード自身がその意味するところを雄弁に語るようになります | self-documenting |
-| ソースコード自身がその意味するところを雄弁に語るようになります | self-documented |
+<!-- | ソースコード自身がその意味するところを雄弁に語るようになります | self-documenting | -->
+<!-- | ソースコード自身がその意味するところを雄弁に語るようになります | self-documented | -->
 | バリアント    | variant       |
 | パターンマッチ | pattern matching |
 | 補助関数       | helper function  |
 | コマンド | Command |
 | サブスクリプション | Subscription |
+<!-- | 章 | chapter | -->
+<!-- | 節 | section | -->

--- a/tool/pretranslate/index.js
+++ b/tool/pretranslate/index.js
@@ -136,6 +136,8 @@ function parseDictionary (content) {
  *  // => true
  *  trContents('|訳語|原文') === null
  *  // => true
+ *  trContents('<!-- |  訳語   |    原文 |  -->')
+ *  // => ['訳語', '原文']
  */
 function trContents (row) {
   const matches = /\| *([^|]+) *\| *([^|]+) *\|/.exec(row);


### PR DESCRIPTION
related to https://github.com/elm-jp/guide/issues/90#issuecomment-431636296

実は `pretranslate` コマンドは ~雑に作ったので~ コメントアウトされた対訳表の行も読み込めるようになっています。

「章」「節」など、特にプログラミングに関係せず、読者が知らなくてもいいが翻訳者間で統一したい対訳はコメントアウトする方針でいい感じにできます。
また、"kitchen knife" <-> "kitchen knives" のように複数形が特殊な活用をする名詞などもコメントアウトをうまく使うことで `pretranslate` 時に原文を正しく解析することが出来るようになります。

@matsubara0507 こんな方針でいかがでしょうか？