### PR TITLE
Change translation for "text field"

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -49,7 +49,7 @@
 * [言語の基礎](core_language.md)
 * [The Elm Architecture](architecture/README.md)
    * [ボタン](architecture/buttons.md)
-   * [テキスト入力](architecture/text_fields.md)
+   * [テキストフィールド](architecture/text_fields.md)
    * [フォーム](architecture/forms.md)
 * [型](types/README.md)
    * [型を読む](types/reading_types.md)

--- a/book/about_translation.md
+++ b/book/about_translation.md
@@ -45,7 +45,7 @@ Elm guide は初学者の方にも分かることを重視したドキュメン�
 |:-----------------:|:---------------:|
 | 型の別名          | type alias      |
 | オブジェクト指向  | object oriented |
-| テキスト入力      | text field      |
+| テキストフィールド| text field      |
 | カスタム型        | custom type     |
 | パターンマッチ    | pattern match   |
 | 相互運用          | interop         |

--- a/book/architecture/README.md
+++ b/book/architecture/README.md
@@ -113,7 +113,7 @@ Your web app is going to need to deal with user input. This section will get you
 -->
 
   - ボタン
-  - テキスト入力
+  - テキストフィールド
   - チェックボックス
   - ラジオボタン
   - そのほか


### PR DESCRIPTION
"text field" の訳を「テキストフィールド」に変更し、統一しました。

This PR closes #100
