### PR TITLE
Translate error handling readme

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -56,7 +56,7 @@
    * [型の別名](types/type_aliases.md)
    * [カスタム型](types/custom_types.md)
    * [パターンマッチ](types/pattern_matching.md)
-* [Error Handling](error_handling/README.md)
+* [エラーハンドリング](error_handling/README.md)
    * [Maybe](error_handling/maybe.md)
    * [Result](error_handling/result.md)
 * [コマンドとサブスクリプション](effects/README.md)

--- a/book/error_handling/README.md
+++ b/book/error_handling/README.md
@@ -8,7 +8,7 @@
 One of the guarantees of Elm is that you will not see runtime errors in practice. This is partly because **Elm treats errors as data**. Rather than crashing, we model the possibility of failure explicitly with custom types. For example, say you want to turn user input into a age. You might create a custom type like this:
 -->
 
-Elmの安全性への保証の1つはランタイムエラーを実際に見ることはないということです。その理由としては **Elmはエラーをデータとして扱うということ** が挙げられます。エラーが起こってアプリケーション全体がクラッシュするよりは失敗の可能性を明示的にカスタム型にモデリングするほうが好まれます。例えば、ユーザからの入力を年齢に変換したいとしましょう。カスタム型をこのように作りましょう:
+Elmが保証してくれる安全性の1つに、ランタイムエラーを実際に見ることはないということがあります。その理由としては **Elmはエラーをデータとして扱うということ** が挙げられます。エラーが起こってアプリケーション全体がクラッシュするよりは失敗の可能性を明示的にカスタム型を使って表現するほうが好まれます。例えば、ユーザからの入力を年齢に変換したいとしましょう。カスタム型をこのように作りましょう:
 
 ```elm
 type MaybeAge
@@ -54,10 +54,10 @@ toPost title content =
 Instead of just saying that the input is invalid, we are describing each of the ways things might have gone wrong. If we have a `viewPreview : MaybePost -> Html msg` function to preview valid posts, now we can give more specific error messages in the preview area when something goes wrong!
 -->
 
-入力が無効であるというだけではなく、入力がどう間違っているかをそれぞれ表現しています。有効な投稿をプレビューするための`viewPreview：MaybePost -> Html msg`関数があれば、何か問題が発生したときにプレビュー領域にもっと具体的なエラーメッセージを表示できるようになりました！
+入力が無効であるというだけではなく、入力がどう間違っているかをそれぞれ表現しています。有効な投稿をプレビューするための`viewPreview：MaybePost -> Html msg`関数があれば、何か問題が発生したときにプレビュー領域にもっと具体的なエラーメッセージを表示できるようになります！
 
 <!--
 These kinds of situations are extremely common. It is often valuable to create a custom type for your exact situation, but in some of the simpler cases, you can use an off-the-shelf type instead. So the rest of this chapter explores the `Maybe` and `Result` types, showing how they can help you treat errors as data!
 -->
 
-このような状況は極めて一般的です。詳しい状況に合わせてカスタム型を作成することはしばしば有益ですが、より単純な場合には代わりに既製の型を使用することができます。それでこの章の残りの部分では`Maybe`型と`Result`型を探り、この2つの型がどのようにエラーをデータとして扱うのを助けることができるかを示します！
+このような状況は極めて一般的です。`Maybe`みたいに汎用な型を使うのではなく、その場その場に合わせてカスタム型を作成したほうがしばしば有益ですが、より単純な場合には代わりに既製の型を使用することができます。それでこの章の残りの部分では`Maybe`型と`Result`型を新たに学び、この2つの型がどのようにエラーをデータとして扱うのを助けることができるかを示します！

--- a/book/error_handling/README.md
+++ b/book/error_handling/README.md
@@ -1,6 +1,14 @@
+<!--
 # Error Handling
+-->
 
+# エラーハンドリング
+
+<!--
 One of the guarantees of Elm is that you will not see runtime errors in practice. This is partly because **Elm treats errors as data**. Rather than crashing, we model the possibility of failure explicitly with custom types. For example, say you want to turn user input into a age. You might create a custom type like this:
+-->
+
+Elmの安全性への保証の1つはランタイムエラーを実際に見ることはないということです。その理由としては **Elmはエラーをデータとして扱うということ** が挙げられます。エラーが起こってアプリケーション全体がクラッシュするよりは失敗の可能性を明示的にカスタム型にモデリングするほうが好まれます。例えば、ユーザからの入力を年齢に変換したいとしましょう。カスタム型をこのように作りましょう:
 
 ```elm
 type MaybeAge
@@ -16,9 +24,16 @@ toAge userInput =
 -- toAge "ZZ" == InvalidInput
 ```
 
+<!--
 Instead of crashing on bad input, we say explicitly that the result may be an `Age 24` or an `InvalidInput`. No matter what input we get, we always produce one of these two variants. From there, we use pattern matching which will ensure that both possibilities are accounted for. No crashing!
+-->
+間違った入力でクラッシュする代わりに、結果が`Age 24`または`InvalidInput`になることを明示的に表現します。どのような入力が得られても、常に2つのバリアントうちの1つを生成します。それからパターンマッチを使って両方の可能性が確実に処理されるようにします。クラッシュはしません！
 
+<!--
 This kind of thing comes up all the time! For example, maybe you want to turn a bunch of user input into a `Post` to share with others. But what happens if they forget to add a title? Or there is no content in the post? We could model all these problems explicitly:
+-->
+
+こういう問題には常に遭遇します！例えば、他の人と共有するために、ユーザからの大量の入力を`Post`型に変換したいとします。しかし、タイトルを入力するのを忘れたらどうなるでしょうか？もしくはその投稿に中身がなかったら？すべての問題を明示的にモデリングしましょう:
 
 ```
 type MaybePost
@@ -35,6 +50,14 @@ toPost title content =
 -- toPost "hi" ""     == NoContent
 ```
 
+<!--
 Instead of just saying that the input is invalid, we are describing each of the ways things might have gone wrong. If we have a `viewPreview : MaybePost -> Html msg` function to preview valid posts, now we can give more specific error messages in the preview area when something goes wrong!
+-->
 
+入力が無効であるというだけではなく、入力がどう間違っているかをそれぞれ表現しています。有効な投稿をプレビューするための`viewPreview：MaybePost -> Html msg`関数があれば、何か問題が発生したときにプレビュー領域にもっと具体的なエラーメッセージを表示できるようになりました！
+
+<!--
 These kinds of situations are extremely common. It is often valuable to create a custom type for your exact situation, but in some of the simpler cases, you can use an off-the-shelf type instead. So the rest of this chapter explores the `Maybe` and `Result` types, showing how they can help you treat errors as data!
+-->
+
+このような状況は極めて一般的です。詳しい状況に合わせてカスタム型を作成することはしばしば有益ですが、より単純な場合には代わりに既製の型を使用することができます。それでこの章の残りの部分では`Maybe`型と`Result`型を探り、この2つの型がどのようにエラーをデータとして扱うのを助けることができるかを示します！

--- a/book/error_handling/README.md
+++ b/book/error_handling/README.md
@@ -60,4 +60,4 @@ Instead of just saying that the input is invalid, we are describing each of the 
 These kinds of situations are extremely common. It is often valuable to create a custom type for your exact situation, but in some of the simpler cases, you can use an off-the-shelf type instead. So the rest of this chapter explores the `Maybe` and `Result` types, showing how they can help you treat errors as data!
 -->
 
-このような状況は極めて一般的です。`Maybe`みたいに汎用な型を使うのではなく、その場その場に合わせてカスタム型を作成したほうがしばしば有益ですが、より単純な場合には代わりに既製の型を使用することができます。それでこの章の残りの部分では`Maybe`型と`Result`型を新たに学び、この2つの型がどのようにエラーをデータとして扱うのを助けることができるかを示します！
+このような状況は極めて一般的です。その場その場に合わせてカスタム型を作成したほうがしばしば有益ですが、より単純な場合には代わりに既製の型を使用することができます。それでこの章の残りの部分では`Maybe`型と`Result`型を新たに学び、この2つの型がどのようにエラーをデータとして扱うのを助けることができるかを示します！


### PR DESCRIPTION
PRを出す時は以下の内容をご確認ください。

- [x] できるだけ他の場所で使われている訳語にあわせる

    [対訳表](https://github.com/elm-jp/guide/blob/master/book/about_translation.md)をご参照ください。
    もし対訳表にまだ記載されていない訳語であれば、対訳表に追記していただけると助かります。

- [x] 原文をコメントアウトしてその直下に訳を記入する
- [x] 事前に `npm start` で正しくレンダリングできていることを確認する
- [x] カタカナ語の採用基準にしたがう
    * 日本語訳が浸透している用語はカタカナ語にしない
    * 日本語訳よりもカタカナ語が十分に浸透していてグーグラビリティなども高い場合は無理に日本語訳をせずにカタカナ表記にする
    * カタカナ語としても日本語としてもあまり浸透しておらず、パッと見で意味が分かる日本語訳もない場合はカタカナ語を推奨する

This PR is a part of #111 