### PR TITLE
Enhance translation

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -96,7 +96,7 @@ Forget what you have heard about functional programming. Fancy words, weird idea
   - Automatically enforced semantic versioning for all Elm packages.
 -->
 まず「関数型プログラミング」について今までに聞いた話をすべて忘れてください。
-なんだかよくわからない用語を使ったり、今まで見たことないような特殊な考え方だったり、実際にアプリケーションを作るのには向いていなかったり...
+なんだかよくわからない用語を使ったり、今まで見たことないような特殊な考え方だったり、実際にアプリケーションを作ろうと思ってもまともなツールがそろってなかったり...
 反吐が出ますね。
 
 Elm はもっと実用的な以下のものを実現するために手段として関数型の考え方を使っているだけです。


### PR DESCRIPTION
ちょっと意訳が飛躍（いやく が ひやく）しすぎたかなって思ってたので修正しました！

- [x] できるだけ他の場所で使われている訳語にあわせる

    [対訳表](https://github.com/elm-jp/guide/blob/master/book/about_translation.md)をご参照ください。
    もし対訳表にまだ記載されていない訳語であれば、対訳表に追記していただけると助かります。

- [x] 原文をコメントアウトしてその直下に訳を記入する
- [x] 事前に `npm start` で正しくレンダリングできていることを確認する
- [x] カタカナ語の採用基準にしたがう
    * 日本語訳が浸透している用語はカタカナ語にしない
    * 日本語訳よりもカタカナ語が十分に浸透していてグーグラビリティなども高い場合は無理に日本語訳をせずにカタカナ表記にする
    * カタカナ語としても日本語としてもあまり浸透しておらず、パッと見で意味が分かる日本語訳もない場合はカタカナ語を推奨する

