### PR TITLE
Fix guide/flags

### DIFF
--- a/book/interop/flags.md
+++ b/book/interop/flags.md
@@ -129,7 +129,7 @@ Many folks always use a `Json.Decode.Value` because it gives them really precise
 The other supported types actually come from before we had figured out a way to do JSON decoders. If you choose to use them, there are some subtleties to be aware of. The following examples show the desired flag type, and then the sub-points show what would happen with a couple different JS values:
 -->
 
-前述のフラグとして渡すことができる型のうち、`Json.Decode.Value` 以外の型は、事前にElmのランタイムシステムが「どうやってJSONをデコードしたら良いか」を算出し、変換された値が渡されます。もしこの方法を使うのなら、いくつか注意することがあります。次の例では、渡そうとしているフラグの型それぞれについて、いろいろなJavaScriptの値を渡すとそれぞれ何が起こるのかを示しています。
+前述のフラグとして渡すことができる型のうち、`Json.Decode.Value` 以外の型は、実はElmにJSONデコーダーを使った方法が導入される前からあるものです。もしこれらの型を使うのなら、いくつか注意することがあります。次の例では、渡そうとしているフラグの型それぞれについて、いろいろなJavaScriptの値を渡すとそれぞれ何が起こるのかを示しています。
 
 - `init : Int -> ...`
   - `0` => `0`


### PR DESCRIPTION
`interop/ports` を読んでる過程で、あの意味がわからないセンテンスの謎が解けました！

- [ ] できるだけ他の場所で使われている訳語にあわせる

    [対訳表](https://github.com/elm-jp/guide/blob/master/book/about_translation.md)をご参照ください。
    もし対訳表にまだ記載されていない訳語であれば、対訳表に追記していただけると助かります。

- [ ] 原文をコメントアウトしてその直下に訳を記入する
- [ ] 事前に `npm start` で正しくレンダリングできていることを確認する
- [ ] カタカナ語の採用基準にしたがう
    * 日本語訳が浸透している用語はカタカナ語にしない
    * 日本語訳よりもカタカナ語が十分に浸透していてグーグラビリティなども高い場合は無理に日本語訳をせずにカタカナ表記にする
    * カタカナ語としても日本語としてもあまり浸透しておらず、パッと見で意味が分かる日本語訳もない場合はカタカナ語を推奨する

