### PR TITLE
Fix for #127

### DIFF
--- a/book/core_language.md
+++ b/book/core_language.md
@@ -384,7 +384,7 @@ It is often useful to update the values in a record.
 It is important to notice that we do not make *destructive* updates. When we update some fields of `bill` we actually create a new record rather than overwriting the existing one. Elm makes this efficient by sharing as much content as possible. If you update one of ten fields, the new record will share the nine unchanged values.
 -->
 
-この構文ではレコードの**破壊的な更新**をしているのではないことに注意してください。`bill`のフィールドを更新したとき、実際には既存のレコードを上書きしているのではなく、新たなレコードが作成されています。効率のため、Elmは新しいレコードの内容を古いレコードとなるべく共有しようとします。もし10個のフィールドのうちのひとつを更新したとしたら、変更されていない残りの9個の値は新しいレコードも共有します。
+この構文ではレコードの**破壊的な更新**をしているのではないことに注意してください。`bill`のフィールドを更新したとき、実際には既存のレコードを上書きしているのではなく、新たなレコードが作成されています。効率のため、Elmは新しいレコードの内容を古いレコードとなるべく共有しようとします。つまり10個のフィールドのうちひとつを更新したとしたら、残り9個の変更されていないフィールドはコピーされるのではなく、新しいレコードと古いレコードで共有される形になります。
 
 
 <!--


### PR DESCRIPTION
#127 対応

PRを出す時は以下の内容をご確認ください。

- [x] できるだけ他の場所で使われている訳語にあわせる

    [対訳表](https://github.com/elm-jp/guide/blob/master/book/about_translation.md)をご参照ください。
    もし対訳表にまだ記載されていない訳語であれば、対訳表に追記していただけると助かります。

- [x] 原文をコメントアウトしてその直下に訳を記入する
- [x] 事前に `npm start` で正しくレンダリングできていることを確認する
- [x] カタカナ語の採用基準にしたがう
    * 日本語訳が浸透している用語はカタカナ語にしない
    * 日本語訳よりもカタカナ語が十分に浸透していてグーグラビリティなども高い場合は無理に日本語訳をせずにカタカナ表記にする
    * カタカナ語としても日本語としてもあまり浸透しておらず、パッと見で意味が分かる日本語訳もない場合はカタカナ語を推奨する

This PR closes #127 (対応するissue番号に変えてください)
