### PR TITLE
「幾つ」を「いくつ」に統一

### DIFF
--- a/book/architecture/README.md
+++ b/book/architecture/README.md
@@ -122,7 +122,7 @@ Your web app is going to need to deal with user input. This section will get you
 We will go through a few examples that build knowledge gradually, so go in order!
 -->
 
-幾つかの例を見ながら徐々に知識を深めていきますので、それではこの順番で進めていきましょう！
+いくつかの例を見ながら徐々に知識を深めていきますので、それではこの順番で進めていきましょう！
 
 
 <!--

--- a/book/core_language.md
+++ b/book/core_language.md
@@ -233,7 +233,7 @@ Lists are one of the most common data structures in Elm. They hold a sequence of
 Lists can hold many values. Those values must all have the same type. Here are a few examples that use functions from the [`List`][list] module:
 -->
 
-リストは複数の値を持つことができますが、それらの値はすべて同じ型を持っていなければなりません。例として、[`List`][list]モジュールから幾つかの関数を見てみましょう。
+リストは複数の値を持つことができますが、それらの値はすべて同じ型を持っていなければなりません。例として、[`List`][list]モジュールからいくつかの関数を見てみましょう。
 
 [list]: https://package.elm-lang.org/packages/elm/core/latest/List
 
@@ -405,7 +405,7 @@ It is important to notice that we do not make *destructive* updates. When we upd
 
 > ### レコードとオブジェクトの比較
 >
-> ElmのレコードはJavaScriptのオブジェクトと**似ています**が、幾つか重要な違いもあります。レコードには次のような特徴があります。
+> ElmのレコードはJavaScriptのオブジェクトと**似ています**が、いくつか重要な違いもあります。レコードには次のような特徴があります。
 >
 > - 存在しないフィールドにアクセスすることはできません。
 > - フィールドが `undefined` や `null`　になることもありません。

--- a/book/interop/ports.md
+++ b/book/interop/ports.md
@@ -248,7 +248,7 @@ Instead, I chose a design that makes synchronization errors impossible. JavaScri
 I want to add a couple notes about the examples we saw here:
 -->
 
-先ほど見てきた例について、ここで幾つか補足を付け加えておきたいと思います。
+先ほど見てきた例について、ここでいくつか補足を付け加えておきたいと思います。
 
 <!--
 - **All `port` declarations must appear in a `port module`.** It is probably best to organize all your ports into one `port module` so it is easier to see the interface all in one place.


### PR DESCRIPTION
一般的に、読みやすさのためなどの理由で同じ単語の漢字表記とひらがな表記が同じ文中に混ざっていても問題はないと思いますが、
「幾つ」という表記については文語っぽさが強くて武士みたいなので「いくつ」にあらためた方が良いかなって思いました。

PRを出す時は以下の内容をご確認ください。

- [x] できるだけ他の場所で使われている訳語にあわせる

    [対訳表](https://github.com/elm-jp/guide/blob/master/book/about_translation.md)をご参照ください。
    もし対訳表にまだ記載されていない訳語であれば、対訳表に追記していただけると助かります。

- [x] 原文をコメントアウトしてその直下に訳を記入する
- [x] 事前に `npm start` で正しくレンダリングできていることを確認する
- [x] 翻訳の方針について[翻訳について](https://github.com/elm-jp/guide/blob/master/book/about_translation.md)を確認した
