### PR TITLE
update uglifyjs option --output

### DIFF
--- a/repl/package.json
+++ b/repl/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "npm run build-js && npm run uglify-js && rimraf elm.js && npm run add-wrapper",
         "build-js": "elm make src/Repl.elm --optimize --output=elm.js",
-        "uglify-js": "uglifyjs elm.js --compress \"pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe\" | uglifyjs --mangle --output=assets/repl.js",
+        "uglify-js": "uglifyjs elm.js --compress \"pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe\" | uglifyjs --mangle --output assets/repl.js",
         "add-wrapper": "cat templates/wrapper.txt >> assets/repl.js"
     },
     "dependencies": {


### PR DESCRIPTION
全然見当違いでしたらごめんなさい、スルーしてください。

october-devを新しくcloneして、`npm i`したところ、エラーが発生してビルドスクリプトが途中で止まってしまいました。
MacでもLinuxでも同じ事象が発生しました。

```bash
> uglifyjs elm.js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" | uglifyjs --mangle --output=assets/repl.js

ERROR: invalid option --output=assets/repl.js
```

uglifyjsのhelpを参照しつつ、--outputのあとを`=`ではなくスペースにしたら動きましたが、以前はここでエラーになった記憶がなく、以前動いた理由がイマイチよくわかっていません。

…とはいえ、とりえあえず動くようにしておいた方が良いのではと思い修正してみました。よろしくお願いいたします。